### PR TITLE
pcsc-lite support for MiSTer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,9 +14,5 @@ go.work
 /bin
 /_bin
 /out
-cmd/remote/_client/build
-scripts/armbuild/_build
-scripts/kernelbuild/_build
-cmd/vplay/_player/*
-!cmd/vplay/_player/README
+scripts/misterbuild/_build
 .DS_Store

--- a/magefile.go
+++ b/magefile.go
@@ -238,7 +238,7 @@ func PrepRelease() {
 	}
 }
 
-func MakeArmApp(name string) {
+func MakeMisterApp(name string) {
 	buildScript := name + ".sh"
 	if _, err := os.Stat(filepath.Join(misterBuild, buildScript)); os.IsNotExist(err) {
 		fmt.Println("No build script for", name)

--- a/scripts/misterbuild/Dockerfile
+++ b/scripts/misterbuild/Dockerfile
@@ -24,6 +24,25 @@ RUN mkdir /internal && cd /internal && \
     make -j "$(nproc)" && \
     make install
 
+# install pcsc-lite and ccid dependencies
+RUN apt-get install -y flex libusb-1.0-0-dev zlib1g-dev
+# install custom version of pcsc-lite
+RUN cd /internal && \
+    wget https://pcsclite.apdu.fr/files/pcsc-lite-2.0.0.tar.bz2 && \
+    tar xf pcsc-lite-2.0.0.tar.bz2 && \
+    cd pcsc-lite-2.0.0 && \
+    ./configure --disable-libsystemd --disable-libudev -enable-static && \
+    make -j "$(nproc)" && \
+    make install
+# install custom version of ccid
+RUN cd /internal && \
+    wget https://ccid.apdu.fr/files/ccid-1.5.4.tar.bz2 && \
+    tar xf ccid-1.5.4.tar.bz2 && \
+    cd ccid-1.5.4 && \
+    ./configure -enable-static && \
+    make -j "$(nproc)" && \
+    make install
+
 # drop permissions on output files
 RUN useradd -m -u 1000 build
 USER build

--- a/scripts/misterbuild/pcsc-lite.sh
+++ b/scripts/misterbuild/pcsc-lite.sh
@@ -1,0 +1,28 @@
+#! /bin/bash
+
+# if [ ! -d pcsc-lite-2.0.0 ]; then
+#     wget https://pcsclite.apdu.fr/files/pcsc-lite-2.0.0.tar.bz2
+#     tar xf pcsc-lite-2.0.0.tar.bz2
+# fi
+
+# cd pcsc-lite-2.0.0 || exit
+
+# ./configure --disable-libsystemd --disable-libudev -enable-static
+# make -j "$(nproc)"
+
+cp /usr/local/sbin/pcscd .
+
+# cd ..
+
+# if [ ! -d ccid-1.5.4 ]; then
+#     wget https://ccid.apdu.fr/files/ccid-1.5.4.tar.bz2
+#     tar xf ccid-1.5.4.tar.bz2
+# fi
+
+# cd ccid-1.5.4 || exit
+
+# ./configure --enable-static
+# make -j "$(nproc)"
+# make install
+
+cp -r /usr/local/lib/pcsc/drivers .


### PR DESCRIPTION
This is an example of getting pcsc-lite working on MiSTer which could potentially add support for the "clone" ACR readers. With pcscd running on the MiSTer I can now see the reader are detected and reporting reads.

On repo:
```
mage makemisterimage
mage makemisterapp pcsc-lite
```

This will results the file `pcscd` and folder `drivers` appearing in `scripts/misterbuild/_build`. Copy these to (for example) /tmp on the MiSTer.

On MiSTer ssh:
```
mkdir -p /usr/local/lib/pcsc
cp -r /tmp/drivers /usr/local/lib/pcsc/
/tmp/pcscd -f -d
```

You can now see hotplugged pcsc compatible readers show up in the output and see some read output.

I don't know yet the best way to implement this support. The only way I can think of is to embed the pcscd binary and drivers folder in the TapTo binary, like we do with the sound files, and deploy them to /tmp on first startup. They're not that big, so I think it's ok, but it still feels like a funny solution.

I haven't tested it yet but I believe there's a pcsc driver included in libnfc. So it could just be a case of updating the connection string with pcscd running.