### PR TITLE
Sorted file listing (split on tabs after sorting)

### DIFF
--- a/scripts/taptui/taptui.sh
+++ b/scripts/taptui/taptui.sh
@@ -1055,8 +1055,8 @@ _EOF_
 
     readarray -t currentDirContents <<< "$( \
       find "${fullPath}" -mindepth 1 -maxdepth 1 \
-      \( -type d -printf '%P\nDirectory\n' \) \
-      -o \( -type f -printf '%P\nFile\n' \))"
+      \( -type d -printf '%P\tDirectory\n' \) \
+      -o \( -type f -printf '%P\tFile\n' \)|sort|tr '\t' '\n')"
 
     selected="$(msg="Pick a game" \
       _menu  --title "${fullPath}" -- "${relativeComponents[@]}" "${currentDirContents[@]}" )"


### PR DESCRIPTION
This keeps the file and type on the same line, tab separated, then splits them back to newline separated after sorting.