### PR TITLE
Just log socket creation error

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -220,7 +220,6 @@ func StartDaemon(cfg *config.UserConfig) (func() error, error) {
 	socket, err := StartSocketServer(st)
 	if err != nil {
 		log.Error().Msgf("error starting socket server: %s", err)
-		return nil, err
 	}
 
 	return func() error {


### PR DESCRIPTION
Since the socket is now only used by external apps, just log and ignore if its creation fails as it's no longer critical to the service running. Issues can still be resolved for external apps by rebooting.

I was going to pull it out into the mister platform module but it also requires implementing the platform-generic config module to resolve a cyclic dependency sooo I didn't do that yet