### PR TITLE
MiSTer script and MGL commands

### DIFF
--- a/cmd/nfc/main.go
+++ b/cmd/nfc/main.go
@@ -60,7 +60,7 @@ import (
 
 const (
 	appName    = "tapto"
-	appVersion = "1.3"
+	appVersion = "1.4-beta1"
 )
 
 func addToStartup() error {

--- a/pkg/daemon/reader.go
+++ b/pkg/daemon/reader.go
@@ -87,7 +87,11 @@ func pollDevice(
 	}
 
 	log.Debug().Msgf("record bytes: %s", hex.EncodeToString(record.Bytes))
-	tagText := tokens.ParseRecordText(record.Bytes)
+	tagText, err := tokens.ParseRecordText(record.Bytes)
+	if err != nil {
+		log.Error().Err(err).Msgf("error parsing NDEF record")
+		tagText = ""
+	}
 
 	if tagText == "" {
 		log.Warn().Msg("no text NDEF found")

--- a/pkg/launcher/commands.go
+++ b/pkg/launcher/commands.go
@@ -230,10 +230,13 @@ func cmdMisterMgl(env *cmdEnv) error {
 		return err
 	}
 
-	err = mrextMister.LaunchGenericFile(
-		mister.UserConfigToMrext(env.cfg),
-		tmpFile.Name(),
-	)
+	cmd, err := os.OpenFile(mister.CmdInterface, os.O_RDWR, 0)
+	if err != nil {
+		return err
+	}
+	defer cmd.Close()
+
+	_, err = cmd.WriteString(fmt.Sprintf("load_core %s\n", tmpFile.Name()))
 	if err != nil {
 		return err
 	}

--- a/pkg/launcher/commands.go
+++ b/pkg/launcher/commands.go
@@ -52,9 +52,10 @@ var commandMappings = map[string]func(*cmdEnv) error{
 	"shell": cmdShell,
 	"delay": cmdDelay,
 
-	"mister.ini":    cmdIni,
-	"mister.core":   cmdLaunchCore,
-	"mister.script": cmdMisterScript,
+	"mister.ini":  cmdIni,
+	"mister.core": cmdLaunchCore,
+	// "mister.script": cmdMisterScript,
+	"mister.mgl": cmdMisterMgl,
 
 	"http.get":  cmdHttpGet,
 	"http.post": cmdHttpPost,
@@ -207,6 +208,42 @@ func cmdMisterScript(env *cmdEnv) error {
 	}
 
 	return mrextMister.RunScript(env.kbd, script)
+}
+
+func cmdMisterMgl(env *cmdEnv) error {
+	if env.args == "" {
+		return fmt.Errorf("no mgl specified")
+	}
+
+	tmpFile, err := os.CreateTemp("", "*.mgl")
+	if err != nil {
+		return err
+	}
+
+	_, err = tmpFile.WriteString(env.args)
+	if err != nil {
+		return err
+	}
+
+	err = tmpFile.Close()
+	if err != nil {
+		return err
+	}
+
+	err = mrextMister.LaunchGenericFile(
+		mister.UserConfigToMrext(env.cfg),
+		tmpFile.Name(),
+	)
+	if err != nil {
+		return err
+	}
+
+	go func() {
+		time.Sleep(5 * time.Second)
+		_ = os.Remove(tmpFile.Name())
+	}()
+
+	return nil
 }
 
 func cmdHttpGet(env *cmdEnv) error {

--- a/pkg/launcher/commands.go
+++ b/pkg/launcher/commands.go
@@ -52,8 +52,9 @@ var commandMappings = map[string]func(*cmdEnv) error{
 	"shell": cmdShell,
 	"delay": cmdDelay,
 
-	"mister.ini":  cmdIni,
-	"mister.core": cmdLaunchCore,
+	"mister.ini":    cmdIni,
+	"mister.core":   cmdLaunchCore,
+	"mister.script": cmdMisterScript,
 
 	"http.get":  cmdHttpGet,
 	"http.post": cmdHttpPost,
@@ -170,6 +171,42 @@ func cmdIni(env *cmdEnv) error {
 	}
 
 	return nil
+}
+
+func cmdMisterScript(env *cmdEnv) error {
+	// TODO: escaping arguments
+	// TODO: does this work if game is running?
+
+	if mrextMister.IsScriptRunning() {
+		return fmt.Errorf("script already running")
+	}
+
+	args := strings.Fields(env.args)
+
+	if len(args) == 0 {
+		return fmt.Errorf("no script specified")
+	}
+
+	script := args[0]
+
+	if !strings.HasSuffix(script, ".sh") {
+		return fmt.Errorf("invalid script: %s", script)
+	}
+
+	scriptPath := filepath.Join(mister.ScriptsFolder, script)
+	if _, err := os.Stat(scriptPath); err != nil {
+		return fmt.Errorf("script not found: %s", script)
+	}
+
+	script = scriptPath
+
+	args = args[1:]
+	if len(args) > 0 {
+		scriptArgs := strings.Join(args, " ")
+		script = fmt.Sprintf("%s %s", script, scriptArgs)
+	}
+
+	return mrextMister.RunScript(env.kbd, script)
 }
 
 func cmdHttpGet(env *cmdEnv) error {

--- a/pkg/platforms/mister/config.go
+++ b/pkg/platforms/mister/config.go
@@ -20,6 +20,7 @@ const (
 	ArcadeDbUrl       = "https://api.github.com/repositories/521644036/contents/ArcadeDatabase_CSV"
 	ArcadeDbFile      = mrextConfig.ScriptsConfigFolder + "/tapto/ArcadeDatabase.csv"
 	ScriptsFolder     = mrextConfig.ScriptsFolder
+	CmdInterface      = "/dev/MiSTer_cmd"
 )
 
 func UserConfigToMrext(cfg *config.UserConfig) *mrextConfig.UserConfig {

--- a/pkg/platforms/mister/config.go
+++ b/pkg/platforms/mister/config.go
@@ -19,6 +19,7 @@ const (
 	GamesDbFile       = mrextConfig.ScriptsConfigFolder + "/tapto/games.db"
 	ArcadeDbUrl       = "https://api.github.com/repositories/521644036/contents/ArcadeDatabase_CSV"
 	ArcadeDbFile      = mrextConfig.ScriptsConfigFolder + "/tapto/ArcadeDatabase.csv"
+	ScriptsFolder     = mrextConfig.ScriptsFolder
 )
 
 func UserConfigToMrext(cfg *config.UserConfig) *mrextConfig.UserConfig {

--- a/pkg/tokens/ndef.go
+++ b/pkg/tokens/ndef.go
@@ -35,21 +35,21 @@ var NDEF_START = []byte{0x54, 0x02, 0x65, 0x6E}
 func ParseRecordText(blocks []byte) (string, error) {
 	startIndex := bytes.Index(blocks, NDEF_START)
 	if startIndex == -1 {
-		return "", fmt.Errorf("NDEF start not found: %v", blocks)
+		return "", fmt.Errorf("NDEF start not found: %x", blocks)
 	}
 
 	endIndex := bytes.Index(blocks, NDEF_END)
 	if endIndex == -1 {
-		return "", fmt.Errorf("NDEF end not found: %v", blocks)
+		return "", fmt.Errorf("NDEF end not found: %x", blocks)
 	}
 
 	startIndex += 4
 	if startIndex >= endIndex || startIndex+4 >= len(blocks) {
-		return "", fmt.Errorf("start index out of bounds: %d, %v", startIndex, blocks)
+		return "", fmt.Errorf("start index out of bounds: %d, %x", startIndex, blocks)
 	}
 
 	if endIndex <= startIndex || endIndex+1 >= len(blocks) {
-		return "", fmt.Errorf("end index out of bounds: %d, %v", endIndex, blocks)
+		return "", fmt.Errorf("end index out of bounds: %d, %x", endIndex, blocks)
 	}
 
 	tagText := string(blocks[startIndex:endIndex])

--- a/pkg/tokens/ndef.go
+++ b/pkg/tokens/ndef.go
@@ -24,6 +24,7 @@ package tokens
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
 
 	"github.com/hsanjuan/go-ndef"
 )
@@ -31,17 +32,29 @@ import (
 var NDEF_END = []byte{0xFE}
 var NDEF_START = []byte{0x54, 0x02, 0x65, 0x6E}
 
-func ParseRecordText(blocks []byte) string {
-	// Find the text NDEF record
+func ParseRecordText(blocks []byte) (string, error) {
 	startIndex := bytes.Index(blocks, NDEF_START)
-	endIndex := bytes.Index(blocks, NDEF_END)
-
-	if startIndex != -1 && endIndex != -1 {
-		tagText := string(blocks[startIndex+4 : endIndex])
-		return tagText
+	if startIndex == -1 {
+		return "", fmt.Errorf("NDEF start not found: %v", blocks)
 	}
 
-	return ""
+	endIndex := bytes.Index(blocks, NDEF_END)
+	if endIndex == -1 {
+		return "", fmt.Errorf("NDEF end not found: %v", blocks)
+	}
+
+	startIndex += 4
+	if startIndex >= endIndex || startIndex+4 >= len(blocks) {
+		return "", fmt.Errorf("start index out of bounds: %d, %v", startIndex, blocks)
+	}
+
+	if endIndex <= startIndex || endIndex+1 >= len(blocks) {
+		return "", fmt.Errorf("end index out of bounds: %d, %v", endIndex, blocks)
+	}
+
+	tagText := string(blocks[startIndex:endIndex])
+
+	return tagText, nil
 }
 
 func BuildMessage(text string) ([]byte, error) {


### PR DESCRIPTION
Add 2 new MiSTer specific commands:

- mister.script - specific and script and optional arguments to be launched as if from the main Scripts menu
- mister.mgl - embed the contents of an mgl file on a tag to be launched