### PR TITLE
Improve write api endpoint

### DIFF
--- a/pkg/daemon/api/readers.go
+++ b/pkg/daemon/api/readers.go
@@ -3,6 +3,7 @@ package api
 import (
 	"errors"
 	"net/http"
+	"time"
 
 	"github.com/go-chi/render"
 	"github.com/rs/zerolog/log"
@@ -34,5 +35,16 @@ func handleReaderWrite(st *state.State) http.HandlerFunc {
 		}
 
 		st.SetWriteRequest(req.Text)
+
+		for st.GetWriteRequest() != "" {
+			time.Sleep(100 * time.Millisecond)
+		}
+
+		if st.GetWriteError() != nil {
+			http.Error(w, st.GetWriteError().Error(), http.StatusInternalServerError)
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
 	}
 }

--- a/pkg/daemon/reader.go
+++ b/pkg/daemon/reader.go
@@ -284,6 +284,7 @@ func readerPollLoop(
 
 			if count == 0 {
 				log.Error().Msgf("could not detect a card")
+				st.SetWriteError(errors.New("could not detect a card"))
 				st.SetWriteRequest("")
 				continue
 			}
@@ -299,6 +300,7 @@ func readerPollLoop(
 				bytesWritten, err = tokens.WriteMifare(pnd, writeRequest, cardUid)
 				if err != nil {
 					log.Error().Msgf("error writing to mifare: %s", err)
+					st.SetWriteError(err)
 					st.SetWriteRequest("")
 					continue
 				}
@@ -306,16 +308,19 @@ func readerPollLoop(
 				bytesWritten, err = tokens.WriteNtag(pnd, writeRequest)
 				if err != nil {
 					log.Error().Msgf("error writing to ntag: %s", err)
+					st.SetWriteError(err)
 					st.SetWriteRequest("")
 					continue
 				}
 			default:
 				log.Error().Msgf("unsupported card type: %s", cardType)
+				st.SetWriteError(errors.New("unsupported card type"))
 				st.SetWriteRequest("")
 				continue
 			}
 
 			log.Info().Msgf("successfully wrote to card: %s", hex.EncodeToString(bytesWritten))
+			st.SetWriteError(nil)
 			st.SetWriteRequest("")
 			continue
 		}

--- a/pkg/daemon/state/state.go
+++ b/pkg/daemon/state/state.go
@@ -34,6 +34,7 @@ type State struct {
 	stopService             bool
 	disableLauncher         bool
 	writeRequest            string
+	writeError              error
 	dbLoadTime              time.Time
 	uidMap                  map[string]string
 	textMap                 map[string]string
@@ -220,4 +221,16 @@ func (s *State) GetWriteRequest() string {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.writeRequest
+}
+
+func (s *State) SetWriteError(err error) {
+	s.mu.Lock()
+	s.writeError = err
+	s.mu.Unlock()
+}
+
+func (s *State) GetWriteError() error {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.writeError
 }


### PR DESCRIPTION
In order to add more supported readers and platforms, we must make libnfc an optional part of the process. It's currently hardcoded in the main poll loop all through it. Still working out the plan, but I think there needs to be a generic "reader" interface each driver like libnfc implements. The driver is specified by the auto-detection, connection string or defaults.