### PR TITLE
add PCSC support to libnfc

### DIFF
--- a/docs/developers.md
+++ b/docs/developers.md
@@ -28,7 +28,7 @@ Most applications use a lot of MiSTer-specific paths and files to function. They
 
 - [Docker](https://www.docker.com/)
 
-  Used for building all the MiSTer binaries. You also need to configure cross-compilation in Docker since ARM images are used for the build process. Podman should also work, but the build scripts use Docker explicitly.
+  Used for building all the MiSTer binaries. You also need to [configure cross-compilation in Docker](https://docs.docker.com/build/building/multi-platform/#building-multi-platform-images) since ARM images are used for the build process. Podman should also work, but the build scripts use Docker explicitly.
   
   On Linux, enable cross-platform builds with something like this: `apt install qemu binfmt-support qemu-user-static`
 
@@ -48,7 +48,7 @@ To start, you can run `go mod download` from the root of the project folder. Thi
 
 All build steps are done with the `mage` command run from the root of the project folder. Run `mage` by itself to see a list of available commands.
 
-Before building MiSTer binaries, you'll also need to build the Docker image it uses. Just run `mage makeArmImage` to add it to your system.
+Before building MiSTer binaries, you'll also need to build the Docker image it uses. Just run `mage makeMisterImage` to add it to your system.
 
 Built binaries will be created in the `bin` directory under its appropriate architecture subdirectory.
 

--- a/magefile.go
+++ b/magefile.go
@@ -62,7 +62,7 @@ var apps = []app{
 		path:         filepath.Join(cwd, "cmd", "nfc"),
 		bin:          "tapto.sh",
 		releaseId:    "mrext/tapto",
-		ldFlags:      "-lnfc -lusb -lcurses",
+		ldFlags:      "-lpcsclite -lnfc -lusb -lcurses",
 		releaseFiles: []string{filepath.Join(cwd, "scripts", "nfcui", "nfcui.sh")},
 	},
 }

--- a/scripts/misterbuild/Dockerfile
+++ b/scripts/misterbuild/Dockerfile
@@ -13,21 +13,10 @@ RUN apt-get install -y ca-certificates openssl && \
 RUN apt-get install build-essential git curl wget ncurses-dev -y && \
     apt-get install golang-doc/bullseye-backports golang-go/bullseye-backports golang-src/bullseye-backports golang/bullseye-backports -y
 
-# install libnfc dependencies
-RUN apt-get install -y libusb-dev libtool autoconf automake
-# install custom version of libnfc
-RUN mkdir /internal && cd /internal && \
-    git clone --depth 1 https://github.com/sam1902/libnfc && \
-    cd libnfc && \
-    autoreconf -vis && \
-    ./configure && \
-    make -j "$(nproc)" && \
-    make install
-
 # install pcsc-lite and ccid dependencies
 RUN apt-get install -y flex libusb-1.0-0-dev zlib1g-dev
 # install custom version of pcsc-lite
-RUN cd /internal && \
+RUN mkdir /internal && cd /internal && \
     wget https://pcsclite.apdu.fr/files/pcsc-lite-2.0.0.tar.bz2 && \
     tar xf pcsc-lite-2.0.0.tar.bz2 && \
     cd pcsc-lite-2.0.0 && \
@@ -40,6 +29,17 @@ RUN cd /internal && \
     tar xf ccid-1.5.4.tar.bz2 && \
     cd ccid-1.5.4 && \
     ./configure -enable-static && \
+    make -j "$(nproc)" && \
+    make install
+
+# install libnfc dependencies
+RUN apt-get install -y libusb-dev libtool autoconf automake
+# install custom version of libnfc
+RUN cd /internal && \
+    git clone --depth 1 https://github.com/sam1902/libnfc && \
+    cd libnfc && \
+    autoreconf -vis && \
+    ./configure --with-drivers=all && \
     make -j "$(nproc)" && \
     make install
 


### PR DESCRIPTION
As discussed on https://github.com/wizzomafizzo/tapto/issues/60, with these changes the CCID card reader gets properly recognized. It's still not enough to use it for scanning as its also pending [changes on libnfc](https://github.com/nfc-tools/libnfc/pull/728) which I'm trying to get upstreamed, but this moves further proper support for PCSC in the right direction.