### PR TITLE
Gamepad input

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require gopkg.in/ini.v1 v1.67.0
 require github.com/fsnotify/fsnotify v1.6.0
 
 require (
-	github.com/bendahl/uinput v1.6.0 // indirect
+	github.com/bendahl/uinput v1.7.0
 	github.com/libp2p/zeroconf/v2 v2.2.0 // indirect
 	github.com/miekg/dns v1.1.55 // indirect
 	github.com/txn2/txeh v1.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 github.com/BurntSushi/toml v1.2.1 h1:9F2/+DoOYIOksmaJFPw1tGFy1eDnIJXg+UHjuD8lTak=
 github.com/ajg/form v1.5.1 h1:t9c7v8JUKu/XxOGBU0yjNpaMloxGEJhUkqFRq0ibGeU=
 github.com/ajg/form v1.5.1/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY=
-github.com/bendahl/uinput v1.6.0 h1:fM6r3OSC17rHh758mizKjSBuqi+XinhiGd4N3pWvZiI=
-github.com/bendahl/uinput v1.6.0/go.mod h1:Np7w3DINc9wB83p12fTAM3DPPhFnAKP0WTXRqCQJ6Z8=
+github.com/bendahl/uinput v1.7.0 h1:nA4fm8Wu8UYNOPykIZm66nkWEyvxzfmJ8YC02PM40jg=
+github.com/bendahl/uinput v1.7.0/go.mod h1:Np7w3DINc9wB83p12fTAM3DPPhFnAKP0WTXRqCQJ6Z8=
 github.com/clausecker/nfc/v2 v2.1.4 h1:zw2Cnny7pxPnuxVMBo+DXqXYETzUN7pMhNEA61yT5gY=
 github.com/clausecker/nfc/v2 v2.1.4/go.mod h1:BjRBQUQTQmiwh2tEfQ+xBM5xY05sV2gnZ0JRYEHog/o=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=

--- a/pkg/launcher/commands.go
+++ b/pkg/launcher/commands.go
@@ -57,9 +57,10 @@ var commandMappings = map[string]func(platforms.Platform, platforms.CmdEnv) erro
 	"http.get":  cmdHttpGet,
 	"http.post": cmdHttpPost,
 
-	"input.key":    cmdKey,
-	"input.coinp1": cmdCoinP1,
-	"input.coinp2": cmdCoinP2,
+	"input.key":     cmdKey,
+	"input.gamepad": cmdGamepad,
+	"input.coinp1":  cmdCoinP1,
+	"input.coinp2":  cmdCoinP2,
 
 	"key":     cmdKey,     // DEPRECATED
 	"coinp1":  cmdCoinP1,  // DEPRECATED
@@ -159,6 +160,10 @@ func cmdHttpPost(pl platforms.Platform, env platforms.CmdEnv) error {
 
 func cmdKey(pl platforms.Platform, env platforms.CmdEnv) error {
 	return pl.KeyboardInput(env.Args)
+}
+
+func cmdGamepad(pl platforms.Platform, env platforms.CmdEnv) error {
+	return pl.GamepadInput(strings.Split(env.Args, ""))
 }
 
 func insertCoin(pl platforms.Platform, env platforms.CmdEnv, key string) error {

--- a/pkg/platforms/platforms.go
+++ b/pkg/platforms/platforms.go
@@ -41,4 +41,5 @@ type Platform interface {
 	Shell(string) error
 	KeyboardInput(string) error
 	ForwardCmd(CmdEnv) error
+	GamepadInput([]string) error
 }


### PR DESCRIPTION
This is an initial example of emulating a gamepad using commands. You can use it like `**input.gamepad:^^VV<><>BAS` to enter the konami code.

The gamepad requires manual mapping in the mister menu before it can be used. This is currently super awkward to do, although you only need to do it once. It may be possible to do something like impersonate a 360 controller and get automatic mapping on most platforms.

Some sort of mini macro language needs to be invented to create the key sequences. This current method only works on 1 character IDs, it will probably be pretty dumb for things like L2 or joysticks (which also don't work yet). It probably also needs things like manually specifying a key down, up, delay, repeat, stuff like that

And it would be good to extend that to the keyboard input command.