### PR TITLE
Add support for launching scripts on MiSTer

### DIFF
--- a/pkg/launcher/commands.go
+++ b/pkg/launcher/commands.go
@@ -46,10 +46,10 @@ var commandMappings = map[string]func(platforms.Platform, platforms.CmdEnv) erro
 	"shell": cmdShell,
 	"delay": cmdDelay,
 
-	"mister.ini":  forwardCmd,
-	"mister.core": forwardCmd,
-	// "mister.script": forwardCmd,
-	"mister.mgl": forwardCmd,
+	"mister.ini":    forwardCmd,
+	"mister.core":   forwardCmd,
+	"mister.script": forwardCmd,
+	"mister.mgl":    forwardCmd,
 
 	"http.get":  cmdHttpGet,
 	"http.post": cmdHttpPost,

--- a/pkg/platforms/mister/commands.go
+++ b/pkg/platforms/mister/commands.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/rs/zerolog/log"
-	"github.com/wizzomafizzo/mrext/pkg/input"
 	"github.com/wizzomafizzo/mrext/pkg/mister"
 	"github.com/wizzomafizzo/tapto/pkg/platforms"
 )
@@ -51,7 +50,7 @@ func CmdLaunchCore(pl platforms.Platform, env platforms.CmdEnv) error {
 	return mister.LaunchShortCore(env.Args)
 }
 
-func cmdMisterScript(kbd input.Keyboard) func(platforms.Platform, platforms.CmdEnv) error {
+func cmdMisterScript(plm Platform) func(platforms.Platform, platforms.CmdEnv) error {
 	return func(pl platforms.Platform, env platforms.CmdEnv) error {
 		args := strings.Fields(env.Args)
 
@@ -74,7 +73,7 @@ func cmdMisterScript(kbd input.Keyboard) func(platforms.Platform, platforms.CmdE
 
 		args = args[1:]
 		if len(args) == 0 {
-			return runScript(kbd, script, "")
+			return runScript(plm, script, "")
 		}
 
 		cleaned := "'"
@@ -99,7 +98,7 @@ func cmdMisterScript(kbd input.Keyboard) func(platforms.Platform, platforms.CmdE
 		cleaned += "'"
 
 		log.Info().Msgf("running script: %s", script+" "+cleaned)
-		return runScript(kbd, script, cleaned)
+		return runScript(plm, script, cleaned)
 	}
 }
 

--- a/pkg/platforms/mister/commands.go
+++ b/pkg/platforms/mister/commands.go
@@ -8,18 +8,11 @@ import (
 	"strings"
 	"time"
 
+	"github.com/rs/zerolog/log"
+	"github.com/wizzomafizzo/mrext/pkg/input"
 	"github.com/wizzomafizzo/mrext/pkg/mister"
 	"github.com/wizzomafizzo/tapto/pkg/platforms"
 )
-
-var commandsMappings = map[string]func(platforms.Platform, platforms.CmdEnv) error{
-	"mister.ini":  CmdIni,
-	"mister.core": CmdLaunchCore,
-	// "mister.script": cmdMisterScript,
-	"mister.mgl": CmdMisterMgl,
-
-	"ini": CmdIni, // DEPRECATED
-}
 
 func CmdIni(pl platforms.Platform, env platforms.CmdEnv) error {
 	inis, err := mister.GetAllMisterIni()
@@ -58,42 +51,56 @@ func CmdLaunchCore(pl platforms.Platform, env platforms.CmdEnv) error {
 	return mister.LaunchShortCore(env.Args)
 }
 
-func cmdMisterScript(pl platforms.Platform, env platforms.CmdEnv) error {
-	// TODO: escaping arguments
-	// TODO: does this work if game is running?
+func cmdMisterScript(kbd input.Keyboard) func(platforms.Platform, platforms.CmdEnv) error {
+	return func(pl platforms.Platform, env platforms.CmdEnv) error {
+		args := strings.Fields(env.Args)
 
-	if mister.IsScriptRunning() {
-		return fmt.Errorf("script already running")
+		if len(args) == 0 {
+			return fmt.Errorf("no script specified")
+		}
+
+		script := args[0]
+
+		if !strings.HasSuffix(script, ".sh") {
+			return fmt.Errorf("invalid script: %s", script)
+		}
+
+		scriptPath := filepath.Join(ScriptsFolder, script)
+		if _, err := os.Stat(scriptPath); err != nil {
+			return fmt.Errorf("script not found: %s", script)
+		}
+
+		script = scriptPath
+
+		args = args[1:]
+		if len(args) == 0 {
+			return runScript(kbd, script, "")
+		}
+
+		cleaned := "'"
+		inQuote := false
+		for _, arg := range strings.Join(args, " ") {
+			if arg == '"' {
+				inQuote = !inQuote
+			}
+
+			if arg == ' ' && !inQuote {
+				cleaned += "' '"
+				continue
+			}
+
+			if arg == '\'' {
+				cleaned += "'\\''"
+				continue
+			}
+
+			cleaned += string(arg)
+		}
+		cleaned += "'"
+
+		log.Info().Msgf("running script: %s", script+" "+cleaned)
+		return runScript(kbd, script, cleaned)
 	}
-
-	args := strings.Fields(env.Args)
-
-	if len(args) == 0 {
-		return fmt.Errorf("no script specified")
-	}
-
-	script := args[0]
-
-	if !strings.HasSuffix(script, ".sh") {
-		return fmt.Errorf("invalid script: %s", script)
-	}
-
-	scriptPath := filepath.Join(ScriptsFolder, script)
-	if _, err := os.Stat(scriptPath); err != nil {
-		return fmt.Errorf("script not found: %s", script)
-	}
-
-	script = scriptPath
-
-	args = args[1:]
-	if len(args) > 0 {
-		scriptArgs := strings.Join(args, " ")
-		script = fmt.Sprintf("%s %s", script, scriptArgs)
-	}
-
-	// TODO: implement without specific reference to uinput.Keyboard
-	// return mister.RunScript(pl.kbd, script)
-	return nil
 }
 
 func CmdMisterMgl(pl platforms.Platform, env platforms.CmdEnv) error {

--- a/pkg/platforms/mister/platform.go
+++ b/pkg/platforms/mister/platform.go
@@ -95,7 +95,7 @@ func (p *Platform) Setup(cfg *config.UserConfig) error {
 	p.cmdMappings = map[string]func(platforms.Platform, platforms.CmdEnv) error{
 		"mister.ini":    CmdIni,
 		"mister.core":   CmdLaunchCore,
-		"mister.script": cmdMisterScript(p.kbd),
+		"mister.script": cmdMisterScript(*p),
 		"mister.mgl":    CmdMisterMgl,
 
 		"ini": CmdIni, // DEPRECATED

--- a/pkg/platforms/mister/scripts.go
+++ b/pkg/platforms/mister/scripts.go
@@ -1,0 +1,109 @@
+package mister
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/wizzomafizzo/mrext/pkg/input"
+)
+
+func openConsole(kbd input.Keyboard) error {
+	getTty := func() (string, error) {
+		sys := "/sys/devices/virtual/tty/tty0/active"
+		if _, err := os.Stat(sys); err != nil {
+			return "", err
+		}
+
+		tty, err := os.ReadFile(sys)
+		if err != nil {
+			return "", err
+		}
+
+		return strings.TrimSpace(string(tty)), nil
+	}
+
+	// we use the F9 key as a means to disable main's usage of the framebuffer and allow scripts to run
+	// unfortunately when the menu "sleeps", any key press will be eaten by main and not trigger the console switch
+	// there's also no simple way to tell if mister has switched to the console
+	// so what we do is switch to tty3, which is unused by mister, then attempt to switch to console,
+	// which sets tty to 1 on success, then check in a loop if it actually did change to 1 and keep pressing F9
+	// until it's switched
+
+	err := exec.Command("chvt", "3").Run()
+	if err != nil {
+		return err
+	}
+
+	tries := 0
+	tty := ""
+	for {
+		if tries > 20 {
+			return fmt.Errorf("could not switch to tty1")
+		}
+		kbd.Console()
+		time.Sleep(50 * time.Millisecond)
+		tty, err = getTty()
+		if err != nil {
+			return err
+		}
+		if tty == "tty1" {
+			break
+		}
+		tries++
+	}
+
+	return nil
+}
+
+func runScript(kbd input.Keyboard, bin string, args string) error {
+	if _, err := os.Stat(bin); err != nil {
+		return err
+	}
+
+	err := openConsole(kbd)
+	if err != nil {
+		return err
+	}
+
+	// this is just to follow mister's convention, which reserves tty2 for scripts
+	err = exec.Command("chvt", "2").Run()
+	if err != nil {
+		return err
+	}
+
+	// this is how mister launches scripts itself
+	launcher := fmt.Sprintf(`#!/bin/bash
+export LC_ALL=en_US.UTF-8
+export HOME=/root
+export LESSKEY=/media/fat/linux/lesskey
+cd $(dirname "%s")
+%s
+`, bin, bin+" "+args)
+
+	err = os.WriteFile("/tmp/script", []byte(launcher), 0755)
+	if err != nil {
+		return err
+	}
+
+	err = exec.Command(
+		"/sbin/agetty",
+		"-a",
+		"root",
+		"-l",
+		"/tmp/script",
+		"--nohostname",
+		"-L",
+		"tty2",
+		"linux",
+	).Run()
+	if err != nil {
+		return err
+	}
+
+	kbd.ExitConsole()
+
+	return nil
+}

--- a/pkg/platforms/mister/scripts.go
+++ b/pkg/platforms/mister/scripts.go
@@ -58,12 +58,20 @@ func openConsole(kbd input.Keyboard) error {
 	return nil
 }
 
-func runScript(kbd input.Keyboard, bin string, args string) error {
+func runScript(pl Platform, bin string, args string) error {
 	if _, err := os.Stat(bin); err != nil {
 		return err
 	}
 
-	err := openConsole(kbd)
+	if pl.GetActiveLauncher() != "" {
+		// menu must be open to switch tty and launch script
+		err := pl.KillLauncher()
+		if err != nil {
+			return err
+		}
+	}
+
+	err := openConsole(pl.kbd)
 	if err != nil {
 		return err
 	}
@@ -103,7 +111,7 @@ cd $(dirname "%s")
 		return err
 	}
 
-	kbd.ExitConsole()
+	pl.kbd.ExitConsole()
 
 	return nil
 }


### PR DESCRIPTION
Adds a mister.scripts command which takes a script filename as an argument and, optionally, some script arguments.

The script must already exist in disk and in the Scripts folder to be launched. Arguments are sanitised to try avoid malicious code. If a game is running when a script is started, the game will be exited.